### PR TITLE
fix: dedent length check in `Tag._all_strings` to run when strip=False

### DIFF
--- a/src/campbells/element/tag_core.py
+++ b/src/campbells/element/tag_core.py
@@ -1399,8 +1399,8 @@ class Tag(PageElement):
                 continue
             if strip:
                 descendant = descendant.strip()
-                if len(descendant) == 0:
-                    continue
+            if len(descendant) == 0:
+                continue
             yield descendant
 
     strings = property(_all_strings)


### PR DESCRIPTION
Potential bugfix, or may be somehow not possible to create a bug [based on how this is used in practice]